### PR TITLE
feat: validate request headers

### DIFF
--- a/src/lib/request-validation-error.ts
+++ b/src/lib/request-validation-error.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/** {@link https://github.com/ts-rest/ts-rest/blob/16501dd6b98bdbfa61c4b371fa23d507088d3213/libs/ts-rest/express/src/lib/request-validation-error.ts | reference} */
+export class RequestValidationError extends Error {
+  constructor(
+    public pathParams: z.ZodError | null,
+    public headers: z.ZodError | null,
+    public query: z.ZodError | null,
+    public body: z.ZodError | null
+  ) {
+    super("[ts-rest] request validation failed");
+  }
+}

--- a/src/lib/test/app.ts
+++ b/src/lib/test/app.ts
@@ -83,6 +83,17 @@ export const router = c.router({
       }),
     },
   },
+  headersRequired: {
+    method: "GET",
+    path: "/headers",
+    summary: "Get a thing but headers are required",
+    headers: z.object({
+      "x-thing": z.string(),
+    }),
+    responses: {
+      200: z.literal("ok"),
+    },
+  },
 });
 
 export const createRouter = c.router({
@@ -143,6 +154,9 @@ const args: RecursiveRouterObj<typeof router, HonoEnv> = {
   },
   createThing: async (_, c) => {
     return { status: 200, body: { ok: true } };
+  },
+  headersRequired: async (_, c) => {
+    return { status: 200, body: "ok" };
   },
 };
 

--- a/src/lib/test/app.ts
+++ b/src/lib/test/app.ts
@@ -151,11 +151,23 @@ const handlers = server.router(router, args);
 createHonoEndpoints(router, handlers, app, {
   logInitialization: true,
   responseValidation(c) {
-    return c.env.ENABLE_RESPONSE_VALIDATION;
+    return c.env.ENABLE_RESPONSE_VALIDATION
   },
-  zodErrorHandler(error) {
-    return { error: formatZodErrors(error), status: 400 };
-  },
+  requestValidationErrorHandler: ({ body, headers, query, pathParams }) => ({
+    error: {
+      errors: {
+        body: body ? formatZodErrors(body) : null,
+        headers: headers ? formatZodErrors(headers) : null,
+        query: query ? formatZodErrors(query) : null,
+        pathParams: pathParams ? formatZodErrors(pathParams) : null,
+      },
+    },
+    status: 400,
+  }),
+  responseValidationErrorHandler: (error) => ({
+    error: formatZodErrors(error),
+    status: 400,
+  }),
 });
 
 app.onError((err, c) => {

--- a/src/lib/test/format-errors.ts
+++ b/src/lib/test/format-errors.ts
@@ -16,24 +16,18 @@ export const validationError = z.object({
 
 export type ValidationError = z.infer<typeof validationError>;
 
-export const errorFormat = z.object({
-  errors: z.array(z.union([error, validationError])),
-});
+export const errorFormat = z.array(z.union([error, validationError]));
 
 export type ErrorFormat = z.infer<typeof errorFormat>;
 
 export function formatZodErrors(zodError: z.ZodError): ErrorFormat {
-  const errors = zodError.errors.map((issue): ValidationError => {
-    return {
-      title: issue.message,
-      detail: issue.code,
-      source: {
-        pointer: `/${issue.path.join("/")}`,
-      },
-    };
-  });
+  const errors = zodError.errors.map((issue): ValidationError => ({
+    title: issue.message,
+    detail: issue.code,
+    source: {
+      pointer: `/${issue.path.join("/")}`,
+    },
+  }));
 
-  return {
-    errors,
-  };
+  return errors;
 }

--- a/src/lib/test/ts-rest-hono.test.ts
+++ b/src/lib/test/ts-rest-hono.test.ts
@@ -135,4 +135,40 @@ describe("Wrangler", () => {
       }
     `);
   });
+
+  describe("validate headers schema in contract", async () => {
+    it("should work for correct headers", async () => {
+      await setupWorker();
+
+      const res = await worker.fetch("/headers", {
+        headers: { "x-thing": "thing" },
+      });
+      expect.soft(res.status).toBe(200);
+      expect(await res.text()).toBe("\"ok\"");
+    });
+    it("should fail if headers aren't given", async () => {
+      await setupWorker();
+
+      const res = await worker.fetch("/headers")
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchInlineSnapshot(`
+        {
+          "errors": {
+            "body": null,
+            "headers": [
+              {
+                "detail": "invalid_type",
+                "source": {
+                  "pointer": "/x-thing",
+                },
+                "title": "Required",
+              },
+            ],
+            "pathParams": null,
+            "query": null,
+          },
+        }
+      `);
+    })
+  });
 });

--- a/src/lib/test/ts-rest-hono.test.ts
+++ b/src/lib/test/ts-rest-hono.test.ts
@@ -118,15 +118,20 @@ describe("Wrangler", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchInlineSnapshot(`
       {
-        "errors": [
-          {
-            "detail": "invalid_type",
-            "source": {
-              "pointer": "/data",
+        "errors": {
+          "body": [
+            {
+              "detail": "invalid_type",
+              "source": {
+                "pointer": "/data",
+              },
+              "title": "Required",
             },
-            "title": "Required",
-          },
-        ],
+          ],
+          "headers": null,
+          "pathParams": null,
+          "query": null,
+        },
       }
     `);
   });

--- a/src/lib/validate-request.ts
+++ b/src/lib/validate-request.ts
@@ -1,0 +1,76 @@
+import {
+  checkZodSchema,
+  parseJsonQueryObject,
+  type AppRoute,
+} from "@ts-rest/core";
+import type { Context } from "hono";
+import {
+  type Options,
+  resolveOption,
+  maybeTransformQueryFromSchema,
+} from "./ts-rest-hono";
+import { RequestValidationError } from "./request-validation-error";
+
+/**
+ * @throws - {@link RequestValidationError}
+ *
+ * {@link https://github.com/ts-rest/ts-rest/blob/16501dd6b98bdbfa61c4b371fa23d507088d3213/libs/ts-rest/express/src/lib/ts-rest-express.ts#L71-L116 | reference}
+ */
+export const validateRequest = (
+  c: Context,
+  schema: AppRoute,
+  options: Options
+) => {
+  const isJsonQueryEnabled = resolveOption(options.jsonQuery, c);
+  const query = isJsonQueryEnabled
+    ? parseJsonQueryObject(c.req.query())
+    : c.req.query();
+
+  const finalQuery = maybeTransformQueryFromSchema(schema, query, c);
+  const queryResult = checkZodSchema(finalQuery, schema.query);
+
+  const paramsResult = checkZodSchema(c.req.param(), schema.pathParams, {
+    passThroughExtraKeys: true,
+  });
+
+  // throw new Error(`Headers are ${JSON.stringify(c.req.header(), null, 2)}`);
+  const headersResult = checkZodSchema(c.req.header(), schema.headers, {
+    passThroughExtraKeys: true,
+  });
+
+  const bodyResult = checkZodSchema(
+    c.req.body,
+    "body" in schema ? schema.body : null
+  );
+
+  if (
+    !paramsResult.success ||
+    !headersResult.success ||
+    !queryResult.success ||
+    !bodyResult.success
+  ) {
+    return new RequestValidationError(
+      !paramsResult.success ? paramsResult.error : null,
+      !headersResult.success ? headersResult.error : null,
+      !queryResult.success ? queryResult.error : null,
+      !bodyResult.success ? bodyResult.error : null
+    );
+  }
+
+  return {
+    params: paramsResult.data,
+    headers: headersResult.data,
+    query: queryResult.data,
+    body: bodyResult.data,
+  };
+};
+
+export const combinedRequestValidationErrorHandler = ({
+  pathParams: pathParamsErrors,
+  headers: headersErrors,
+  query: queryErrors,
+  body: bodyErrors,
+}: RequestValidationError) => ({
+  error: { pathParamsErrors, headersErrors, queryErrors, bodyErrors },
+  status: 400,
+});


### PR DESCRIPTION
- blocked by: #10 

## Changes

- extracted request validation into `validateRequest` to match with https://github.com/ts-rest/ts-rest/blob/16501dd6b98bdbfa61c4b371fa23d507088d3213/libs/ts-rest/express/src/lib/ts-rest-express.ts#L71-L116
- removed `zodErrorHandler` from options and splitted them into `requestValidationErrorHandler` and `responseValidationErrorHandler`
- added tests for headers
